### PR TITLE
fix value rounding issue in remmy

### DIFF
--- a/src/lib/utils/converters.ts
+++ b/src/lib/utils/converters.ts
@@ -2,4 +2,4 @@ import type { Size } from './types';
 
 export const decimal = (value: string | number, places: number) => +parseFloat(value.toString()).toFixed(places);
 
-export const convertToRem = (size: Size, rem: number) => ({ value: decimal(size.value / rem, 5), unit: 'rem' });
+export const convertToRem = (size: Size, rem: number) => ({ raw: `${decimal(size.value / rem, 5)}rem`, value: decimal(size.value / rem, 5), unit: 'rem' });

--- a/src/lib/utils/parsers.ts
+++ b/src/lib/utils/parsers.ts
@@ -94,18 +94,13 @@ const rgba = z
 
 export const color = z.union([hex, hsl, hsla, named, rgb, rgba]);
 
-const pixel = z.custom<`${number}px`>((val) => regex.pixel.test(val as string)).transform((val) => ({ value: parseFloat(val.replace('px', '')), unit: 'px' }));
+const pixel = z.custom<`${number}px`>((val) => regex.pixel.test(val as string)).transform((val) => ({ raw: val, value: parseFloat(val.replace('px', '')), unit: 'px' }));
 
 type pixel = z.infer<typeof pixel>;
 
-const point = z.custom<`${number}pt`>((val) => regex.point.test(val as string)).transform((val) => ({ value: parseFloat(val.replace('pt', '')), unit: 'pt' }));
+const point = z.custom<`${number}pt`>((val) => regex.point.test(val as string)).transform((val) => ({ raw: val, value: parseFloat(val.replace('pt', '')), unit: 'pt' }));
 
 type point = z.infer<typeof point>;
-
-const sizeObject = z.object({
-	value: z.number(),
-	unit: z.string()
-});
 
 export const size = z.union([pixel, point]);
 

--- a/src/lib/utils/text.ts
+++ b/src/lib/utils/text.ts
@@ -3,8 +3,8 @@ export const regex = {
 	byEmptyLines: /\n\s*\n/,
 	byLine: /\r?\n|\r|\n/g,
 	hex: /^#(?:[0-9a-fA-F]{2}){3,4}$/,
-	pixel: /(?<!["'\(])\d\.?\d*px(?!["'\)])/,
-	point: /(?<!["'\(])\d\.?\d*pt(?!["'\)])/,
+	pixel: /(?<!["'\(])\d+\.?\d*px(?!["'\)])/,
+	point: /(?<!["'\(])\d+\.?\d*pt(?!["'\)])/,
 	semicolon: /;(?!.*[)"])/
 };
 

--- a/src/lib/utils/transformers.ts
+++ b/src/lib/utils/transformers.ts
@@ -30,7 +30,7 @@ export const replaceSizes = (stylesheet: string, sizes: Converted<Size>[]) => {
 		.filter((val, i, arr) => arr.findIndex((val2) => JSON.stringify(val2.original) === JSON.stringify(val.original)) === i)
 		.sort((a, b) => (a.original.value % 1 != 0 ? -1 : b.original.value % 1 != 0 ? 1 : b.original.value - a.original.value));
 
-	let findr = sortedSizes.map((size) => ({ find: `${size.original.value}${size.original.unit}`, replace: `${size.converted.value}${size.converted.unit}` }));
+	let findr = sortedSizes.map((size) => ({ find: size.original.raw, replace: size.converted.raw }));
 
 	return replaceMany(stylesheet, findr);
 };

--- a/src/lib/utils/types.ts
+++ b/src/lib/utils/types.ts
@@ -4,6 +4,7 @@ export type Converted<T> = {
 };
 
 export type Size = {
+	raw: string;
 	value: number;
 	unit: string;
 };


### PR DESCRIPTION
Parsing the float during Zod parsing was causing the original values to be rounded somewhat unexpectedly, this fix keeps hold of the original raw value and uses that to find and replace, instead of the rounded value. The end result values are still rounded. 